### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,5 +1,8 @@
 name: Build and Push to GHCR
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/cbulock/iptv-proxy/security/code-scanning/6](https://github.com/cbulock/iptv-proxy/security/code-scanning/6)

To fix this issue, we need to define a `permissions` block in the workflow file to limit the permissions of the `GITHUB_TOKEN` to only what is necessary for the workflow to operate. Based on the workflow's steps, the job does not require write access to repository contents, but it does interact with the GitHub Container Registry. Therefore, we should set the `contents: read` permission globally or within the specific job.

The fix involves adding the following permissions block at the root level of the workflow:
```yaml
permissions:
  contents: read
```

This ensures that all jobs in the workflow have minimal privileges unless explicitly overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
