### PR TITLE
Potential fix for code scanning alert no. 31: Exposure of private files

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,8 +30,10 @@ app.use(express.json({ limit: '1mb' }));
 // Use absolute path for static assets to avoid CWD issues
 const publicDir = path.resolve('./public');
 app.use(express.static(publicDir));
-// Serve node_modules to allow ESM imports without a bundler
-app.use('/node_modules', express.static(path.resolve('./node_modules')));
+// Optionally serve node_modules in development to allow ESM imports without a bundler
+if (process.env.NODE_ENV === 'development') {
+  app.use('/node_modules', express.static(path.resolve('./node_modules')));
+}
 // Load and validate config
 const configs = loadAllConfigs();
 


### PR DESCRIPTION
Potential fix for [https://github.com/cbulock/iptv-proxy/security/code-scanning/31](https://github.com/cbulock/iptv-proxy/security/code-scanning/31)

In general, the fix is to stop serving the entire `node_modules` tree and instead expose only the specific subdirectories or files that the frontend actually needs, or eliminate direct serving of `node_modules` entirely in favor of bundling or copying required assets into the existing `public` directory.

The least-invasive fix, without changing existing behavior more than necessary, is:

- Remove the line that serves `./node_modules` wholesale.
- Replace it with explicit static mounts for the specific packages that must be accessible to the browser (if any). For example, if only a couple of frontend libraries are used directly from `node_modules`, mount only their `dist` folders at dedicated paths (e.g. `/vendor/react`, `/vendor/some-lib`). This preserves the ability to import those assets over HTTP while not exposing all of `node_modules`.
- If no such direct usage exists or we can rely on the existing `public` directory, we can simply remove the `app.use('/node_modules', ...)` line entirely.

Because the snippet does not show which specific node modules are needed, and we must not assume additional structure, the safest and still functional generic fix is to remove the `node_modules` static mount and add a guarded development-only version if needed, controlled via `NODE_ENV`. This way, production deployments will not expose private files, while local development can still opt in. Concretely, in `index.js` around line 31–35:
- Keep `publicDir` handling as is.
- Replace the `app.use('/node_modules', express.static(path.resolve('./node_modules')));` line with a conditional that only serves node_modules when `process.env.NODE_ENV === 'development'` (or remove it outright if we want maximum safety).

No new imports are required; we can reuse the existing `path` import and `express.static`. The changes are all within `index.js` near the existing static configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
