### PR TITLE
Potential fix for code scanning alert no. 55: Reflected cross-site scripting

### DIFF
--- a/libs/proxy-image.js
+++ b/libs/proxy-image.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import getBaseUrl from './getBaseUrl.js';
+import escapeHtml from 'escape-html';
 
 export function getProxiedImageUrl(originalUrl, source, req) {
   if (!originalUrl) return '';
@@ -17,11 +18,11 @@ export function imageProxyRoute(app) {
       console.warn(`Failed to fetch image from ${decodedUrl}: ${err.message}`);
       // Return a more helpful error message
       if (err.response?.status === 404) {
-        res.status(404).send(`Image not found: ${decodedUrl}`);
+        res.status(404).send(`Image not found: ${escapeHtml(decodedUrl)}`);
       } else if (err.response?.status === 403) {
-        res.status(403).send(`Access denied to image: ${decodedUrl}`);
+        res.status(403).send(`Access denied to image: ${escapeHtml(decodedUrl)}`);
       } else if (err.code === 'ENOTFOUND') {
-        res.status(502).send(`Cannot resolve hostname for image: ${decodedUrl}`);
+        res.status(502).send(`Cannot resolve hostname for image: ${escapeHtml(decodedUrl)}`);
       } else {
         res.status(502).send(`Failed to fetch image from source`);
       }


### PR DESCRIPTION
Potential fix for [https://github.com/cbulock/iptv-proxy/security/code-scanning/55](https://github.com/cbulock/iptv-proxy/security/code-scanning/55)

To fix the problem, the user-controlled value (`decodedUrl`) must not be written into an HTML response without appropriate encoding. The general remedy is to apply contextual output encoding (HTML-escaping in this case) before including user input in the response body, or to avoid echoing the user input at all. Using a battle-tested HTML-escaping library is preferable to hand-rolled functions.

The best fix with minimal behavior change is to HTML-escape `decodedUrl` in all error messages that interpolate it (404, 403, and ENOTFOUND cases) before sending. We can introduce a small helper `escapeHtml` function in this file, or, since we are allowed to add well-known dependencies, we can import a standard library like `escape-html` and use it. That keeps the responses human-readable while neutralizing any tags or scripts inside the URL. Concretely, in `libs/proxy-image.js`, add an import for `escape-html` at the top, then wrap `decodedUrl` with `escape()` (or similar) in the `res.status(...).send(...)` calls on lines 20, 22, and 24. No other logic or behavior needs to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
