### PR TITLE
Potential fix for code scanning alert no. 24: Use of externally-controlled format string

### DIFF
--- a/server/lineup.js
+++ b/server/lineup.js
@@ -182,7 +182,10 @@ export function setupLineupRoutes(app, config, usageHelpers = {}) {
       if (usageKey) unregisterUsage(usageKey);
       if (usageInterval) clearInterval(usageInterval);
       console.warn(
-        `[stream] failed ${source}/${name}: ${err.message}`,
+        '[stream] failed %s/%s: %s',
+        source,
+        name,
+        err.message,
         {
           status: err.response?.status,
           code: err.code


### PR DESCRIPTION
Potential fix for [https://github.com/cbulock/iptv-proxy/security/code-scanning/24](https://github.com/cbulock/iptv-proxy/security/code-scanning/24)

In general, to fix this issue you must ensure that untrusted input (here, `source` and `name`) is not used as the format string for `console`-style functions. Instead of interpolating untrusted data directly into the first argument, use a fixed format string with `%s` placeholders and pass untrusted values as subsequent arguments, or avoid Node’s formatting altogether by pre-building the message as a single string and passing no additional arguments.

For this particular code, the minimal fix that preserves existing behavior is to change the `console.warn` call at lines 184–189 so that the first argument is a constant string with format specifiers, and `source`, `name`, and `err.message` are passed as additional arguments. The second argument remains the structured object containing `status` and `code`, so logs are still structured the same way. No new imports or helper methods are needed.

Concretely, in `server/lineup.js`:
- Replace

  ```js
  console.warn(
    `[stream] failed ${source}/${name}: ${err.message}`,
    {
      status: err.response?.status,
      code: err.code
    }
  );
  ```

- With something like:

  ```js
  console.warn(
    '[stream] failed %s/%s: %s',
    source,
    name,
    err.message,
    {
      status: err.response?.status,
      code: err.code
    }
  );
  ```

This keeps the same semantics but ensures the format string is constant and not tainted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
