### PR TITLE
Potential fix for code scanning alert no. 23: Use of externally-controlled format string

### DIFF
--- a/server/lineup.js
+++ b/server/lineup.js
@@ -118,17 +118,20 @@ export function setupLineupRoutes(app, config, usageHelpers = {}) {
     if (!channel) return res.status(404).send('Channel not found');
 
     const startTime = Date.now();
-    console.info(`[stream] ${source}/${name} -> ${channel.original_url}`);
+    console.info('[stream] %s/%s -> %s', source, name, channel.original_url);
 
     if (req.method === 'HEAD') {
       try {
         const response = await axios.head(channel.original_url, { timeout: 5000 });
         res.set(response.headers);
         res.status(response.status || 200).end();
-        console.info(`[stream] ${source}/${name} head ok in ${Date.now() - startTime}ms`);
+        console.info('[stream] %s/%s head ok in %dms', source, name, Date.now() - startTime);
       } catch (err) {
         console.warn(
-          `[stream] head failed ${source}/${name}: ${err.message}`,
+          '[stream] head failed %s/%s: %s',
+          source,
+          name,
+          err.message,
           {
             status: err.response?.status,
             code: err.code
@@ -171,18 +174,21 @@ export function setupLineupRoutes(app, config, usageHelpers = {}) {
       await registerViewer();
 
       response.data.on('error', err => {
-        console.warn(`[stream] upstream error ${source}/${name}: ${err.message}`);
+        console.warn('[stream] upstream error %s/%s: %s', source, name, err.message);
         res.destroy(err);
       });
 
       res.set(response.headers);
       response.data.pipe(res);
-      console.info(`[stream] ${source}/${name} ready in ${Date.now() - startTime}ms`);
+      console.info('[stream] %s/%s ready in %dms', source, name, Date.now() - startTime);
     } catch (err) {
       if (usageKey) unregisterUsage(usageKey);
       if (usageInterval) clearInterval(usageInterval);
       console.warn(
-        `[stream] failed ${source}/${name}: ${err.message}`,
+        '[stream] failed %s/%s: %s',
+        source,
+        name,
+        err.message,
         {
           status: err.response?.status,
           code: err.code


### PR DESCRIPTION
Potential fix for [https://github.com/cbulock/iptv-proxy/security/code-scanning/23](https://github.com/cbulock/iptv-proxy/security/code-scanning/23)

In general, to fix a user-controlled format string issue in Node.js logging, you should avoid embedding untrusted data directly into the *format string* (the first string argument to `console.log`/`console.warn`/`util.format`). Instead, use literal format strings with `%s` placeholders and pass any untrusted values as subsequent arguments. This preserves the ability to log structured information while preventing user input from being interpreted as format specifiers.

For this file, the best fix is to change the affected `console.info`/`console.warn` calls so that:
- The first argument is a constant string with `%s` placeholders for `source`, `name`, and `err.message` where appropriate.
- `source`, `name`, and `err.message` are passed as additional arguments rather than being interpolated into the format string via template literals.

Concretely, in `server/lineup.js`:
- Around line 121: replace ``console.info(`[stream] ${source}/${name} -> ${channel.original_url}`);`` with `console.info('[stream] %s/%s -> %s', source, name, channel.original_url);`
- Around line 128: replace ``console.info(`[stream] ${source}/${name} head ok in ${Date.now() - startTime}ms`);`` with `console.info('[stream] %s/%s head ok in %dms', source, name, Date.now() - startTime);`
- Around line 130–135: replace the warning with a literal format string plus object argument, e.g.  
  `console.warn('[stream] head failed %s/%s: %s', source, name, err.message, { status: ..., code: ... });`
- Around line 174: replace the upstream error log similarly.
- Around line 180: replace the "ready" log with a format string plus placeholders.
- Around line 184–189: replace the final `console.warn` with a literal format string plus `%s` and object argument.

This keeps functionality identical (same information is logged) but ensures user-supplied `source`/`name` values cannot influence the format string itself.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
