### PR TITLE
Potential fix for code scanning alert no. 22: Missing rate limiting

### DIFF
--- a/server/mapping.js
+++ b/server/mapping.js
@@ -2,12 +2,18 @@ import express from 'express';
 import fs from 'fs/promises';
 import { loadConfig } from '../libs/config-loader.js';
 import { getConfigPath, getDataPath } from '../libs/paths.js';
+import rateLimit from 'express-rate-limit';
 
 const router = express.Router();
 const CHANNELS_FILE = getDataPath('channels.json');
 const CHANNEL_MAP_FILE = getConfigPath('channel-map.yaml');
 
-router.get('/api/mapping/conflicts', async (req, res) => {
+const conflictsLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs for this endpoint
+});
+
+router.get('/api/mapping/conflicts', conflictsLimiter, async (req, res) => {
   try {
     let channels = [];
     try { channels = JSON.parse(await fs.readFile(CHANNELS_FILE, 'utf8')); } catch {}


### PR DESCRIPTION
Potential fix for [https://github.com/cbulock/iptv-proxy/security/code-scanning/22](https://github.com/cbulock/iptv-proxy/security/code-scanning/22)

To fix the problem, introduce request rate limiting on the `/api/mapping/conflicts` route so that an attacker cannot trigger unbounded concurrent filesystem reads and processing. In Express, this is typically done using a middleware such as `express-rate-limit` that tracks requests per client over a time window and rejects or delays excess requests.

The best minimal fix, without changing existing behavior of the handler itself, is to (1) import `express-rate-limit` at the top of `server/mapping.js`, (2) create a limiter instance configured specifically for this router or route, and (3) apply that limiter to the `/api/mapping/conflicts` endpoint. This leaves the core logic of reading `CHANNELS_FILE`, building the `conflicts` list, and returning JSON unchanged while adding a guard against excessive calls. Concretely, in `server/mapping.js`, add a `rateLimit` import alongside the existing imports, define a `const conflictsLimiter = rateLimit({...})` near the router initialization, and then change `router.get('/api/mapping/conflicts', async (req, res) => { ... })` so that the handler is preceded by this middleware, e.g., `router.get('/api/mapping/conflicts', conflictsLimiter, async (req, res) => { ... })`. No other functions or files need to be modified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
