### PR TITLE
Potential fix for code scanning alert no. 30: Missing rate limiting

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -171,7 +171,7 @@ router.put('/api/config/app', configWriteLimiter, (req, res) => {
   }
 });
 
-router.put('/api/config/channel-map', (req, res) => {
+router.put('/api/config/channel-map', configWriteLimiter, (req, res) => {
   const incoming = req.body || {};
   const validation = validateConfigData('channelMap', incoming);
   if (!validation.valid) return res.status(400).json({ 


### PR DESCRIPTION
Potential fix for [https://github.com/cbulock/iptv-proxy/security/code-scanning/30](https://github.com/cbulock/iptv-proxy/security/code-scanning/30)

In general, to fix missing rate limiting on an Express route that performs expensive operations (like synchronous file writes), you should apply an appropriate rate-limiting middleware to that route (or group of routes). This can be done using a library such as `express-rate-limit`, typically with a limiter instance configured elsewhere and reused for all sensitive routes.

In this file, `configWriteLimiter` is already being used on other config-write routes (`/api/config/m3u` and `/api/config/epg`), and `express-rate-limit` is already imported as `RateLimit` at the top. The best fix with minimal behavioral change is therefore to apply the same `configWriteLimiter` middleware to the `/api/config/channel-map` route. Concretely, on line 174 we should change `router.put('/api/config/channel-map', (req, res) => {` to `router.put('/api/config/channel-map', configWriteLimiter, (req, res) => {`. This reuses the existing limiter configuration, keeps behavior consistent with the other config writing endpoints, and does not change the core functionality of the handler beyond adding protection against rapid repeated requests.

No new imports or helper methods are needed because the rate limiter is already defined and imported elsewhere in this file (as evidenced by its use on the other routes).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
